### PR TITLE
Relax Builder dependency.

### DIFF
--- a/scruffy.gemspec
+++ b/scruffy.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = "1.3.6"
   s.summary = "Scruffy is a library for outputting graphs to image or SVG"
 
-  s.add_dependency 'builder', '~> 2.0'
+  s.add_dependency 'builder', '>= 2.0'
   # This shouldn't be a dependency, as it's possible to use Scruffy without it.
 #  s.add_dependency 'rmagick', '~> 2.0'
   s.add_development_dependency 'rspec', '~> 2.3'


### PR DESCRIPTION
It seems that the test suite passes against Builder 3.0.0, so the dependency can be relaxed.
